### PR TITLE
#47-投稿画面と一覧画面の統合他 #50 #51 #54 など

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,7 +3,7 @@
 }
 
 #console {
-  width: 410px; /*固定したい幅の長さ*/
+  width: 440px; /*固定したい幅の長さ*/
 }
 
 #grid {
@@ -28,7 +28,7 @@
 }
 
 #image_url_text_box {
-  width: 400px;
+  width: 432px;
 }
 
 #console_reaction_img {
@@ -47,6 +47,8 @@
   height: 80px;
   box-sizing:border-box;
   border: 1px solid #000000;
+  margin-right: 8px;
+  margin-bottom: 8px;
 }
 
 .cell {

--- a/index.css
+++ b/index.css
@@ -11,6 +11,16 @@
   box-sizing: border-box;
 }
 
+#gauge {
+  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+  padding-top: 8px;
+}
+
+#display_time {
+  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+  padding-top: 4px;
+}
+
 @media screen and (min-width: 401px) {
   #stamp_grid_view {
     width: 400px;

--- a/index.css
+++ b/index.css
@@ -95,12 +95,10 @@
   color: #fff;
   background: rgba(0,0,0,.8);
   width: 100%;
-  padding: 1em 0;
 }
 
 .caption p {
   margin: 0;
-  padding: 0 0.8em;
   font-size: 200%;
   text-align: center;
 }

--- a/index.css
+++ b/index.css
@@ -1,26 +1,36 @@
-@media screen and (min-width: 641px) {
+#console {
+  width: 400px;
+  float: left;
+}
+
+#grid {
+  float: right;
+  width: 100%;
+  margin-left: -410px;
+  padding-left: 410px;
+  box-sizing: border-box;
+}
+
+@media screen and (min-width: 401px) {
   #stamp_grid_view {
-    width: 640px;
+    width: 400px;
   }
   #img {
     width: 100%;
   }
 }
 
-@media screen and (max-width: 640px) {
+@media screen and (max-width: 400px) {
   #stamp_grid_view {
     width: 100%;
   }
   #img {
     width: 100%;
   }
-}
-
-#image_url_input {
 }
 
 #image_url_text_box {
-  width: 480px;
+  width: 400px;
 }
 
 #console_reaction_img {
@@ -92,4 +102,8 @@
   padding: 0 0.8em;
   font-size: 200%;
   text-align: center;
+}
+
+#grid_user_input {
+  height: 24px;
 }

--- a/index.css
+++ b/index.css
@@ -1,17 +1,13 @@
 #wrapper {
-  float: right;
-  width: 100%;
-  margin-left: -400px;
+  display: flex;
 }
 
 #console {
-  float: left;
-  width: 400px;
+  width: 410px; /*固定したい幅の長さ*/
 }
 
 #grid {
-  position: relative;
-  margin-left: 410px;
+  flex: 1;
 }
 
 #gauge {
@@ -24,22 +20,11 @@
   padding-top: 4px;
 }
 
-@media screen and (min-width: 401px) {
-  #stamp_grid_view {
-    width: 400px;
-  }
-  #img {
-    width: 100%;
-  }
+#stamp_grid_view {
+  width: 100%;
 }
-
-@media screen and (max-width: 400px) {
-  #stamp_grid_view {
-    width: 100%;
-  }
-  #img {
-    width: 100%;
-  }
+#img {
+  width: 100%;
 }
 
 #image_url_text_box {

--- a/index.css
+++ b/index.css
@@ -56,6 +56,7 @@
   box-sizing:border-box;
   border: 1px solid #000000;
   position: relative;
+  overflow: hidden;
 }
 
 .user_image {

--- a/index.css
+++ b/index.css
@@ -1,14 +1,17 @@
+#wrapper {
+  float: right;
+  width: 100%;
+  margin-left: -400px;
+}
+
 #console {
-  width: 400px;
   float: left;
+  width: 400px;
 }
 
 #grid {
-  float: right;
-  width: 100%;
-  margin-left: -410px;
-  padding-left: 410px;
-  box-sizing: border-box;
+  position: relative;
+  margin-left: 410px;
 }
 
 #gauge {

--- a/index.html
+++ b/index.html
@@ -6,31 +6,33 @@
     <style type="text/css">@import "index.css";</style>
   </head>
   <body>
-    <div id="console">
-      <div id="name_input">
-        Twitter ID: @<input type="text" value="test" id="name_text_box">
-        <button type="button" id="grid_switch_button"> 一覧非表示 </button>
+    <div id="wrapper">
+      <div id="console">
+        <div id="name_input">
+          Twitter ID: @<input type="text" value="test" id="name_text_box">
+          <button type="button" id="grid_switch_button"> 一覧非表示 </button>
+        </div>
+        <div id="console_reaction_img">
+          <img src="https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png" id="img">
+        </div>
+        <div id="gauge">[░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]</div>
+        <div id="display_time">0秒</div>
+        <div id="image_url_input">
+          Image URL: <br><input type="text" value="" id="image_url_text_box"><br>
+          <button type="button" id="image_url_add_button"> 追加 </button>
+          <button type="button" id="image_url_delete_button"> 削除 </button>
+        </div>
+        <div id="stamp_grid_view"></div>
       </div>
-      <div id="console_reaction_img">
-        <img src="https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png" id="img">
+      <div id="grid">
+        <div id="grid_user_input">
+          <input type="text" value="" id="twitter_id_text_box">
+          <button type="button" id="cell_add_button"> 追加 </button>
+          <button type="button" id="cell_delete_button"> 削除 </button>
+          <button type="button" id="console_switch_button"> 投稿非表示 </button>
+        </div>
+        <div id="grid_view"></div>
       </div>
-      <div id="gauge">[░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]</div>
-      <div id="display_time">0秒</div>
-      <div id="image_url_input">
-        Image URL: <br><input type="text" value="" id="image_url_text_box"><br>
-        <button type="button" id="image_url_add_button"> 追加 </button>
-        <button type="button" id="image_url_delete_button"> 削除 </button>
-      </div>
-      <div id="stamp_grid_view"></div>
-    </div>
-    <div id="grid">
-      <div id="grid_user_input">
-        <input type="text" value="" id="twitter_id_text_box">
-        <button type="button" id="cell_add_button"> 追加 </button>
-        <button type="button" id="cell_delete_button"> 削除 </button>
-        <button type="button" id="console_switch_button"> 投稿非表示 </button>
-      </div>
-      <div id="grid_view"></div>
     </div>
     <script src="//linda-server.herokuapp.com/linda/linda.js"></script>
     <script src="dist/index.js"></script>

--- a/index.html
+++ b/index.html
@@ -25,9 +25,11 @@
     </div>
     <div id="grid">
       <div id="grid_user_input">
+        <!--
         <input type="text" value="" id="twitter_id_text_box">
         <button type="button" id="twitter_id_add_button"> 追加 </button>
         <button type="button" id="twitter_id_delete_button"> 削除 </button>
+        -->
         <button type="button" id="console_switch_button"> 投稿非表示 </button>
       </div>
       <div id="grid_view"></div>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <title>わかるらんど</title>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
-    <link rel="stylesheet" href="index.css" />
+    <style type="text/css">@import "index.css";</style>
   </head>
   <body>
     <div id="console">
@@ -25,7 +25,7 @@
     </div>
     <div id="grid">
       <div id="grid_user_input">
-        Twitter ID: @<input type="text" value="" id="twitter_id_text_box">
+        <input type="text" value="" id="twitter_id_text_box">
         <button type="button" id="twitter_id_add_button"> 追加 </button>
         <button type="button" id="twitter_id_delete_button"> 削除 </button>
         <button type="button" id="console_switch_button"> 投稿非表示 </button>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
       <div id="console_reaction_img">
         <img src="https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png" id="img">
       </div>
-      <div id="gauge">[⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂]</div>
+      <div id="gauge">[░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]</div>
       <div id="display_time">0秒</div>
       <div id="image_url_input">
         Image URL: <br><input type="text" value="" id="image_url_text_box"><br>
@@ -25,11 +25,9 @@
     </div>
     <div id="grid">
       <div id="grid_user_input">
-        <!--
         <input type="text" value="" id="twitter_id_text_box">
-        <button type="button" id="twitter_id_add_button"> 追加 </button>
-        <button type="button" id="twitter_id_delete_button"> 削除 </button>
-        -->
+        <button type="button" id="cell_add_button"> 追加 </button>
+        <button type="button" id="cell_delete_button"> 削除 </button>
         <button type="button" id="console_switch_button"> 投稿非表示 </button>
       </div>
       <div id="grid_view"></div>

--- a/index.html
+++ b/index.html
@@ -9,21 +9,29 @@
     <div id="console">
       <div id="name_input">
         Twitter ID: @<input type="text" value="test" id="name_text_box">
-      </div>
-      <div id="image_url_input">
-        Image URL: <input type="text" value="" id="image_url_text_box">
-        <button type="button" id="image_url_add_button"> + </button>
-        <button type="button" id="image_url_delete_button"> - </button>
+        <button type="button" id="grid_switch_button"> 一覧非表示 </button>
       </div>
       <div id="console_reaction_img">
         <img src="https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png" id="img">
       </div>
       <div id="gauge">[⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂]</div>
       <div id="display_time">0秒</div>
-      <div id="switch_menu">▼ Reaction</div>
+      <div id="image_url_input">
+        Image URL: <br><input type="text" value="" id="image_url_text_box"><br>
+        <button type="button" id="image_url_add_button"> 追加 </button>
+        <button type="button" id="image_url_delete_button"> 削除 </button>
+      </div>
       <div id="stamp_grid_view"></div>
     </div>
-    <div id="grid_view"></div>
+    <div id="grid">
+      <div id="grid_user_input">
+        Twitter ID: @<input type="text" value="" id="twitter_id_text_box">
+        <button type="button" id="twitter_id_add_button"> 追加 </button>
+        <button type="button" id="twitter_id_delete_button"> 削除 </button>
+        <button type="button" id="console_switch_button"> 投稿非表示 </button>
+      </div>
+      <div id="grid_view"></div>
+    </div>
     <script src="//linda-server.herokuapp.com/linda/linda.js"></script>
     <script src="dist/index.js"></script>
   </body>

--- a/src/index.js
+++ b/src/index.js
@@ -260,6 +260,7 @@ console.log(display_users);
 const createUserCell = (from, cellWidth, cellHeight) => {
   const cell = document.createElement("div");
   cell.setAttribute("class", "cell");
+  cell.setAttribute("div", from);
 
   const user_icon_layer = document.createElement("img");
   user_icon_layer.setAttribute("class", "user_image");
@@ -379,13 +380,23 @@ const switch_grid = () => {
   const grid_style = document.getElementById("grid").style;
   const console_button = document.getElementById("console_switch_button");
   const grid_button = document.getElementById("grid_switch_button");
+  const stamp_grid = document.getElementById("stamp_grid_view");
+  const console = document.getElementById("console");
   if (grid_style.display == "block") {
     grid_style.display = "none";
-    grid_button.innerHTML = " 一覧表示 "
+    grid_button.innerHTML = " 一覧表示 ";
+    console.style.width = "100%";
+    stamp_grid.style.width = "100%";
   } else {
+    console.style.width = 400;
     grid_style.display = "block";
     console_button.innerHTML = " 投稿非表示 ";
     grid_button.innerHTML = " 一覧非表示 ";
+    if (window.innerWidth > 400) {
+      stamp_grid.style.width = 400;
+    } else {
+      stamp_grid.style.width = "100%";
+    }
   }
 };
 
@@ -394,13 +405,20 @@ const switch_console = () => {
   const console_style = document.getElementById("console").style;
   const console_button = document.getElementById("console_switch_button");
   const grid_button = document.getElementById("grid_switch_button");
+  const grid = document.getElementById("grid");
   if (console_style.display == "block") {
     console_style.display = "none";
-    console_button.innerHTML = " 投稿表示 "
+    console_button.innerHTML = " 投稿表示 ";
+    grid.style.float = "left";
+    grid.style.marginLeft = 0;
+    grid.style.paddingLeft = 0;
   } else {
     console_style.display = "block";
     console_button.innerHTML = " 投稿非表示 ";
     grid_button.innerHTML = " 一覧非表示 ";
+    grid.style.float = "right";
+    grid.style.marginLeft = -410;
+    grid.style.paddingLeft = 410;
   }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,13 @@ $('#grid_switch_button').on("click", () => {
   switch_grid();
 });
 
+$('#cell_add_button').on("click", () => {
+  append_user(document.getElementById("twitter_id_text_box").value);
+});
+
+$('#cell_delete_button').on("click", () => {
+  remove_user(document.getElementById("twitter_id_text_box").value);
+});
 
 import SocketIO from 'socket.io-client'
 
@@ -155,7 +162,7 @@ const startCount = () => {
     if (mousedown_count <= 30) {
       const gauge = document.getElementById("gauge").innerHTML;
       const second = mousedown_count * 20;
-      document.getElementById("gauge").innerHTML = gauge.slice(0, mousedown_count) + "░" + gauge.slice(mousedown_count + 1);
+      document.getElementById("gauge").innerHTML = gauge.slice(0, mousedown_count) + "█" + gauge.slice(mousedown_count + 1);
       if (second <= 20) {
         document.getElementById("display_time").innerHTML = "20秒";
       } else if (second >= 600) {
@@ -196,7 +203,7 @@ const appendStampCell = (img_url, append_last) => {
       console.log(second + "sec < " + img_url);
     }
     mousedown_count = 0;
-    document.getElementById("gauge").innerHTML = "[⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂]";
+    document.getElementById("gauge").innerHTML = "[░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]";
   });
   cell.appendChild(img);
 
@@ -441,6 +448,26 @@ const relayout_grid = () => {
       reaction_img_layer.removeAttribute("height");
     }
   }
+};
+
+var append_user = (from) => {
+  let cell;
+  if (sensors.includes(from)) {
+    cell = appendSensorCell(from);
+  } else {
+    cell = appendUserCell(from);
+  }
+  document.getElementById("grid_view").appendChild(cell);
+  display_users.push(from);
+  history.replaceState("", "", "?" + display_users.join(","));
+  relayout_grid();
+};
+
+var remove_user = (from) => {
+  // document.getElementById("grid_view").removeChild(document.getElementById(from));
+  // display_users.splice()
+  // history.replaceState("", "", "?" + display_users.join(","));
+  // relayout_grid();
 };
 
 // ローカルストレージまたはURL末尾のクエリから発言者名の設定

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ const sensor_images = {
 };
 
 // レイアウトの定数
-const CONSOLE_WIDTH = 410;
+const CONSOLE_WIDTH = 440;
 const GRID_USER_INPUT_HEIGHT = 24;
 
 // connect Socket.IO & Linda
@@ -361,14 +361,13 @@ const switch_grid = () => {
   const grid_style = document.getElementById("grid").style;
   const console_button = document.getElementById("console_switch_button");
   const grid_button = document.getElementById("grid_switch_button");
-  const stamp_grid = document.getElementById("stamp_grid_view");
   const console = document.getElementById("console");
   if (grid_style.display == "block") {
     console.style.width = "100%";
     grid_style.display = "none";
     grid_button.innerHTML = " 一覧表示 ";
   } else {
-    console.style.width = 410;
+    console.style.width = CONSOLE_WIDTH;
     grid_style.display = "block";
     console_button.innerHTML = " 投稿非表示 ";
     grid_button.innerHTML = " 一覧非表示 ";
@@ -438,9 +437,6 @@ const relayout_grid = () => {
   }
 };
 
-const indexOfChild = () => {
-};
-
 var append_user = (from) => {
   let cell;
   if (sensors.includes(from)) {
@@ -455,10 +451,16 @@ var append_user = (from) => {
 };
 
 var remove_user = (from) => {
-  // document.getElementById("grid_view").removeChild(document.getElementById(from));
-  // display_users.splice()
-  // history.replaceState("", "", "?" + display_users.join(","));
-  // relayout_grid();
+  document.getElementById("grid_view").removeChild(document.getElementById(from));
+  for (let i in display_users) {
+    if (from == display_users[i]) {
+      display_users.splice(i, 1);
+      break;
+    }
+  }
+  console.log(display_users);
+  history.replaceState("", "", "?" + display_users.join(","));
+  relayout_grid();
 };
 
 // ローカルストレージまたはURL末尾のクエリから発言者名の設定
@@ -500,8 +502,14 @@ for (let i in display_users) {
   document.getElementById("grid_view").appendChild(cell);
 }
 
-document.getElementById("console").style.display = "block";
-document.getElementById("grid").style.display = "block";
+if (display_users.length == 0 ||
+    (display_users.length == 1 && (display_users[0] == "" || display_users[0].charAt(0) == "@"))) {
+  document.getElementById("console").style.display = "block";
+  document.getElementById("grid").style.display = "none";
+} else {
+  document.getElementById("console").style.display = "none";
+  document.getElementById("grid").style.display = "block";
+}
 relayout_grid();
 
 $(window).resize(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -391,16 +391,14 @@ const switch_console = () => {
   if (console_style.display == "block") {
     console_style.display = "none";
     console_button.innerHTML = " 投稿表示 ";
-    grid.style.float = "left";
-    grid.style.marginLeft = 0;
-    grid.style.paddingLeft = 0;
+    grid.style.width = "100%";
+    grid.style.marginLeft = "0";
   } else {
     console_style.display = "block";
     console_button.innerHTML = " 投稿非表示 ";
     grid_button.innerHTML = " 一覧非表示 ";
-    grid.style.float = "right";
-    grid.style.marginLeft = -410;
-    grid.style.paddingLeft = 410;
+    grid.style.width = "";
+    grid.style.marginLeft = "410";
   }
   relayout_grid();
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,15 @@ $('#image_url_delete_button').on("click", () => {
   removeImage()
 });
 
+$('#console_switch_button').on("click", () => {
+  switch_console();
+});
+
+$('#grid_switch_button').on("click", () => {
+  switch_grid();
+});
+
+
 import SocketIO from 'socket.io-client'
 
 const default_icons = [
@@ -40,387 +49,411 @@ const sensor_images = {
   "enoshima_wind": "https://i.gyazo.com/d13f222ba330bf686b6cdcd98b264464.png"
 };
 
+// レイアウトの定数
+const CONSOLE_WIDTH = 410;
+const GRID_USER_INPUT_HEIGHT = 24;
+
 // connect Socket.IO & Linda
 const server_url = "//linda-server.herokuapp.com/";
 const socket = SocketIO(server_url);
 const linda = new Linda().connect(socket);
 const ts = linda.tuplespace("masuilab");
 
+linda.io.on("connect", () => {
+  console.log("connect Linda!!");
+  ts.watch({from: my_name}, (err, tuple) => {
+    console.log(my_name+" < " + tuple.data.value);
+    document.getElementById("img").src = tuple.data.value;
+  });
+
+  // 一覧表示
+  for (let i in display_users) {
+    if (display_users[i].charAt(0) == "@") {
+      ts.watch({from: display_users[i]}, (err, tuple) => {
+        const reactor = tuple.data.from;
+        if (display_users.includes(reactor)) {
+          const img_url = tuple.data.value;
+          const time = tuple.data.time;
+          const ip_address = tuple.from;
+          console.log(reactor + " < " + img_url + " " + time + "sec (from " + ip_address + ")");
+          document.getElementById(reactor + "_reaction").src = img_url;
+          document.getElementById(reactor + "_image").style.opacity = 0.25;
+          if (time != 0) {
+            withdrawReaction(reactor, time * 1000);
+          }
+        }
+      });
+    }
+  }
+
+  // デルタのセンサ
+  if (display_users.includes("delta_temperature")) {
+    ts.watch({where: "delta", type: "sensor", name: "temperature"}, (err, tuple) => {
+      const temp = Math.round(tuple.data.value * 10) / 10;
+      console.log("delta_temperature = " + temp);
+      document.getElementById("delta_temperature_value_text").innerHTML = temp + "℃";
+    });
+  }
+
+  if (display_users.includes("delta_light")) {
+    ts.watch({where: "delta", type: "sensor", name: "light"}, (err, tuple) => {
+      const value = tuple.data.value;
+      console.log("delta_light = " + value);
+      document.getElementById("delta_light_value_text").innerHTML = value;
+      if (value <= 100) {
+        document.getElementById("delta_light_image").src = sensor_images["delta_light"];
+      } else {
+        document.getElementById("delta_light_image").src = sensor_images["delta_light_on"];
+      }
+    });
+  }
+
+  if (display_users.includes("delta_door")) {
+    ts.watch({where: "delta", type: "door", cmd: "open"}, (err, tuple) => {
+      console.log("delta_door_open!!");
+      const date = new Date();
+      const minute = date.getMinutes() > 10 ? date.getMinutes() : "0" + date.getMinutes();
+      const second = date.getSeconds() > 10 ? date.getSeconds() : "0" + date.getSeconds();
+      document.getElementById("delta_door_value_text").innerHTML =
+          "Last OPEN " + date.getHours()+ ":" + minute + ":" + second;
+      document.getElementById("delta_door_image").src = sensor_images["delta_door_open"];
+      window.setTimeout(() => {
+        document.getElementById("delta_door_image").src = sensor_images["delta_door"];
+      }, 10000);
+    });
+  }
+
+  // 江ノ島の風
+  if (display_users.includes("enoshima_wind")) {
+    ts.watch({where: "enoshima", type: "sensor", name: "wind"}, (err, tuple) => {
+      document.getElementById("enoshima_wind_value_text").innerHTML =
+          tuple.data.direction + " の風 " + tuple.data.speed + "m/s";
+    });
+  }
+});
+
 // URL末尾のカンマ区切り文字列から表示するユーザを抽出
 const display_users = Array.from(new Set(location.search.substring(1).split(',')));
 
-if (display_users.length == 0 ||
-    (display_users.length == 1 && (display_users[0].charAt(0) == "@" || display_users[0] == ""))) {
-  /**
-   * console リアクション投稿ページ
-   * URL末尾に何も書かない、Twitterユーザ名が1人のとき
-   */
+//if (display_users.length == 0 ||
+//    (display_users.length == 1 && (display_users[0].charAt(0) == "@" || display_users[0] == ""))) {
 
-  let myName = "test";
-  if (display_users.length == 0 || display_users[0] == "") {
-    if (window.localStorage) {
-      myName = localStorage.name || myName;
-    }
-  } else {
-    myName = display_users[0];
+let my_name = "test";
+if (display_users.length == 0 || display_users[0] == "") {
+  if (window.localStorage) {
+    my_name = localStorage.name || my_name;
   }
-  document.getElementById("name_text_box").value = myName.substring(1);
+} else {
+  my_name = display_users[0];
+}
+document.getElementById("name_text_box").value = my_name.substring(1);
 
-  linda.io.on("connect", () => {
-    console.log("connect Linda!!");
-    ts.watch({from: myName}, (err, tuple) => {
-      console.log(myName+" < " + tuple.data.value);
-      document.getElementById("img").src = tuple.data.value;
-    });
-  });
+var sendReaction = (reaction, time) => {
+  my_name = "@" + document.getElementById("name_text_box").value;
+  if (window.localStorage) localStorage.name = my_name;
+  document.getElementById("img").src = reaction;
+  document.getElementById(reaction + "_cell").style.backgroundColor = "#ffffff";
+  ts.write({from: my_name, value: reaction, time: time});
+  if (default_icons.includes(reaction)) {
+    document.getElementById("image_url_text_box").value = "";
+  } else {
+    document.getElementById("image_url_text_box").value = reaction;
+  }
+};
 
-  var sendReaction = (reaction, time) => {
-    myName = "@" + document.getElementById("name_text_box").value;
-    if (window.localStorage) localStorage.name = myName;
-    document.getElementById("img").src = reaction;
-    document.getElementById(reaction + "_cell").style.backgroundColor = "#ffffff";
-    ts.write({from: myName, value: reaction, time: time});
-    if (default_icons.includes(reaction)) {
-      document.getElementById("image_url_text_box").value = "";
-    } else {
-      document.getElementById("image_url_text_box").value = reaction;
-    }
-  };
-
-  let mousedown_id;
-  let mousedown_count = 0;
-  const startCount = () => {
-    mousedown_id = setInterval(() => {
-      mousedown_count += 1;
-      if (mousedown_count <= 30) {
-        const gauge = document.getElementById("gauge").innerHTML;
-        const second = mousedown_count * 20;
-        document.getElementById("gauge").innerHTML = gauge.slice(0, mousedown_count) + "░" + gauge.slice(mousedown_count + 1);
-        if (second <= 20) {
-          document.getElementById("display_time").innerHTML = "20秒";
-        } else if (second >= 600) {
-          document.getElementById("display_time").innerHTML = "forever";
-        } else {
-          document.getElementById("display_time").innerHTML = second + "秒";
-        }
-      }
-    }, 100);
-  };
-
-  // スタンプの一覧に画像を追加する
-  const appendStampCell = (img_url, append_last) => {
-    const cell = document.createElement("div");
-    cell.setAttribute("class", "icon");
-    cell.setAttribute("id", img_url + "_cell");
-    cell.setAttribute("style", "background-color:#ffffff");
-    const img = document.createElement("img");
-    img.setAttribute("id", img_url);
-    img.setAttribute("src", img_url);
-    img.setAttribute("width", "100%");
-    img.addEventListener("mousedown", () => {
-      startCount(img_url);
-    });
-  
-    img.addEventListener("mouseup", () => {
-      clearInterval(mousedown_id);
+let mousedown_id;
+let mousedown_count = 0;
+const startCount = () => {
+  mousedown_id = setInterval(() => {
+    mousedown_count += 1;
+    if (mousedown_count <= 30) {
+      const gauge = document.getElementById("gauge").innerHTML;
       const second = mousedown_count * 20;
+      document.getElementById("gauge").innerHTML = gauge.slice(0, mousedown_count) + "░" + gauge.slice(mousedown_count + 1);
       if (second <= 20) {
         document.getElementById("display_time").innerHTML = "20秒";
-        sendReaction(img_url, 20);
-        console.log("30sec < " + img_url);
       } else if (second >= 600) {
-        sendReaction(img_url, 0);
-        console.log("forever < " + img_url);
+        document.getElementById("display_time").innerHTML = "forever";
       } else {
-        sendReaction(img_url, second);
-        console.log(second + "sec < " + img_url);
-      }
-      mousedown_count = 0;
-      document.getElementById("gauge").innerHTML = "[⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂]";
-    });
-    cell.appendChild(img);
-
-    if (append_last) {
-      document.getElementById("stamp_grid_view").appendChild(cell);
-    } else {
-      const stamp_grid_view = document.getElementById("stamp_grid_view");
-      stamp_grid_view.insertBefore(cell, stamp_grid_view.firstChild);
-    }
-  };
-
-  let my_images = "";
-
-  // 自分で追加した画像を削除
-  var removeImage = () => {
-    console.log("removeImage()");
-    const img_url = document.getElementById("image_url_text_box").value;
-    const my_images_array = Array.from(new Set(my_images.split(',')));
-    if (my_images_array.includes(img_url)) {
-      console.log("my_images_array includes " + img_url);
-      for (let i in my_images_array) {
-        console.log("my_images_array[i] = " + my_images_array[i], "img_url = " + img_url);
-        if (my_images_array[i] == img_url) {
-          console.log(img_url + " is removed!");
-          document.getElementById("stamp_grid_view").removeChild(document.getElementById(img_url + "_cell"));
-          my_images_array.splice(i, 1);
-          localStorage.images = my_images_array;
-          break;
-        }
+        document.getElementById("display_time").innerHTML = second + "秒";
       }
     }
-  };
+  }, 100);
+};
 
-  // URLから画像を追加
-  var addImage = () => {
-    const img_url = document.getElementById("image_url_text_box").value
-    appendStampCell(img_url, false);
-    if (my_images != "") {
-      my_images = my_images + ",";
-    }
-    my_images = my_images + img_url;
-    localStorage.images = my_images;
-  };
-
-  // 一覧表示は使わないので削除
-  const gridView = document.getElementById("grid_view");
-  gridView.parentNode.removeChild(gridView);
-
-  // デフォルトで用意してある画像を表示
-  for (let i in default_icons) {
-    appendStampCell(default_icons[i], true);
-  }
-
-  // localStorageから自分で追加した画像を表示
-  my_images = localStorage.images || my_images;
-  if (my_images.length != "") {
-    const my_images_array = Array.from(new Set(my_images.split(',')));
-    for (let i in my_images_array) {
-      console.log(my_images_array[i]);
-      appendStampCell(my_images_array[i], false);
-    }
-  }
-
-} else {
-  /**
-   * grid ユーザの一覧ページ
-   * URL末尾に2人以上Twitterユーザ名を書いたとき、1つ以上Twitterユーザ名【以外】を書いたとき
-   */
-  console.log(display_users);
-  // 表示する人/物/現象のViewを動的に生成する
-  const createUserCell = (from, cellWidth, cellHeight) => {
-    const cell = document.createElement("div");
-    cell.setAttribute("class", "cell");
-
-    const user_icon_layer = document.createElement("img");
-    user_icon_layer.setAttribute("class", "user_image");
-    user_icon_layer.setAttribute("id", from + "_image");
-    user_icon_layer.setAttribute("src", "http://www.paper-glasses.com/api/twipi/" + from.substring(1) + "/original");
-
-    const reaction_img_layer = document.createElement("img");
-    reaction_img_layer.setAttribute("class", "reaction_image");
-    reaction_img_layer.setAttribute("id", from + "_reaction");
-    reaction_img_layer.setAttribute("src", "https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png");
-
-    if (cellWidth >= cellHeight) {
-      user_icon_layer.setAttribute("height", "100%");
-      reaction_img_layer.setAttribute("height", "100%");
-    } else {
-      user_icon_layer.setAttribute("width", "100%");
-      reaction_img_layer.setAttribute("width", "100%");
-    }
-
-    cell.appendChild(user_icon_layer);
-    cell.appendChild(reaction_img_layer);
-    return cell;
-  };
-
-  const createSensorCell = (from, cellWidth, cellHeight) => {
-    const cell = document.createElement("div");
-    cell.setAttribute("class", "cell");
-    
-    const sensor_img_layer = document.createElement("img");
-    sensor_img_layer.setAttribute("class", "sensor_image");
-    sensor_img_layer.setAttribute("id", from + "_image");
-    sensor_img_layer.setAttribute("src", sensor_images[from]);
-    
-    const sensor_value_text_layer = document.createElement("figcaption");
-    sensor_value_text_layer.setAttribute("class", "caption");
-    
-    const sensor_value_text = document.createElement("p");
-    sensor_value_text.setAttribute("id", from + "_value_text");
-
-    if (cellWidth >= cellHeight) {
-      sensor_img_layer.setAttribute("height", "100%");
-    } else {
-      sensor_img_layer.setAttribute("width", "100%");
-    }
-
-    sensor_value_text_layer.appendChild(sensor_value_text);
-    cell.appendChild(sensor_img_layer);
-    cell.appendChild(sensor_value_text_layer);
-    return cell;
-  };
-
-  // ウィンドウサイズと表示数からグリッドの列数と行数を算出する
-  const getGridSize = (windowWidth, windowHeight, minCellWidth, itemCount) => {
-    if (itemCount <= 1) {
-      return { "columnCount": 1, "rowCount": 1 };
-    }
-
-    if (windowWidth >= windowHeight) {
-      if ((windowWidth / windowHeight) * 2 > itemCount) {
-        return { "columnCount": itemCount, "rowCount": 1 }
-      }
-    } else {
-      if ((windowHeight / windowWidth) * 2 > itemCount) {
-        return { "columnCount": 1, "rowCount": itemCount }
-      }
-    }
-
-    const cellAspectRatio = 1.0;
-    const minCellHeight = minCellWidth / cellAspectRatio;
-    const maxColumnCount = Math.min(Math.floor(windowWidth / minCellWidth), itemCount);
-    const minRowCount = Math.ceil(itemCount / maxColumnCount);
-    if (windowHeight < minRowCount * minCellHeight) {
-      return { "columnCount": maxColumnCount, "rowCount": minRowCount };
-    }
-
-    let columnCount = maxColumnCount - 1;
-    let rowCount = Math.ceil(itemCount / columnCount);
-    while (columnCount > 1) {
-      const prevColumnCount = columnCount + 1;
-      const prevRowCount = Math.ceil(itemCount / prevColumnCount);
-      if (Math.min(windowWidth / columnCount, windowHeight / rowCount)
-          < Math.min(windowWidth / prevColumnCount, windowHeight / prevRowCount)) {
-        return { "columnCount": prevColumnCount, "rowCount": prevRowCount }
-      } else {
-        columnCount -= 1;
-        rowCount = Math.ceil(itemCount / columnCount);
-      }
-    }
-    if (windowWidth >= windowHeight) return { "columnCount": Math.ceil(itemCount / 2), "rowCount": 2 };
-    else return { "columnCount": 2, "rowCount": Math.ceil(itemCount / 2) };
-  };
-
-  // 指定時間後に発言を非表示にする
-  let timer_ids = {};
-  const withdrawReaction = (reactor, time) => {
-    if (time == 0 && reactor in timer_ids) {
-      window.clearTimeout(timer_ids[reactor]);
-    } else {
-      if (reactor in timer_ids) {
-        window.clearTimeout(timer_ids[reactor]);
-      }
-      console.log("time = " + time + "msec");
-      timer_ids[reactor] = window.setTimeout(() => {
-        console.log("withdraw -> " + reactor);
-        if (sensors.includes(reactor)) {
-          document.getElementById(reactor + "_image").src = sensor_images[reactor];
-        } else {
-          document.getElementById(reactor + "_reaction").src = "https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png";
-          document.getElementById(reactor + "_image").style.opacity = 1.0;
-        }
-      }, time);
-    }
-  };
-
-  linda.io.on("connect", function(){
-    console.log("connect Linda!!");
-
-    for (let i in display_users) {
-      if (display_users[i].charAt(0) == "@") {
-        ts.watch({from: display_users[i]}, (err, tuple) => {
-          const reactor = tuple.data.from;
-          if (display_users.includes(reactor)) {
-            const img_url = tuple.data.value;
-            const time = tuple.data.time;
-            const ip_address = tuple.from;
-            console.log(reactor + " < " + img_url + " " + time + "sec (from " + ip_address + ")");
-            document.getElementById(reactor + "_reaction").src = img_url;
-            document.getElementById(reactor + "_image").style.opacity = 0.25;
-            if (time != 0) {
-              withdrawReaction(reactor, time * 1000);
-            }
-          }
-        });
-      }
-    }
-
-    if (display_users.includes("delta_temperature")) {
-      ts.watch({where: "delta", type: "sensor", name: "temperature"}, (err, tuple) => {
-        const temp = Math.round(tuple.data.value * 10) / 10;
-        console.log("delta_temperature = " + temp);
-        document.getElementById("delta_temperature_value_text").innerHTML = temp + "℃";
-      });
-    }
-
-    if (display_users.includes("delta_light")) {
-      ts.watch({where: "delta", type: "sensor", name: "light"}, (err, tuple) => {
-        const value = tuple.data.value;
-        console.log("delta_light = " + value);
-        document.getElementById("delta_light_value_text").innerHTML = value;
-        if (value <= 100) {
-          document.getElementById("delta_light_image").src = sensor_images["delta_light"];
-        } else {
-          document.getElementById("delta_light_image").src = sensor_images["delta_light_on"];
-        }
-      });
-    }
-
-    if (display_users.includes("delta_door")) {
-      ts.watch({where: "delta", type: "door", cmd: "open"}, (err, tuple) => {
-        console.log("delta_door_open!!");
-        const date = new Date();
-        const minute = date.getMinutes() > 10 ? date.getMinutes() : "0" + date.getMinutes();
-        const second = date.getSeconds() > 10 ? date.getSeconds() : "0" + date.getSeconds();
-        document.getElementById("delta_door_value_text").innerHTML =
-            "Last OPEN " + date.getHours()+ ":" + minute + ":" + second;
-        document.getElementById("delta_door_image").src = sensor_images["delta_door_open"];
-        window.setTimeout(() => {
-          document.getElementById("delta_door_image").src = sensor_images["delta_door"];
-        }, 10000);
-      });
-    }
-
-    if (display_users.includes("enoshima_wind")) {
-      ts.watch({where: "enoshima", type: "sensor", name: "wind"}, (err, tuple) => {
-        document.getElementById("enoshima_wind_value_text").innerHTML =
-            tuple.data.direction + " の風 " + tuple.data.speed + "m/s";
-      });
-    }
+// スタンプの一覧に画像を追加する
+const appendStampCell = (img_url, append_last) => {
+  const cell = document.createElement("div");
+  cell.setAttribute("class", "icon");
+  cell.setAttribute("id", img_url + "_cell");
+  cell.setAttribute("style", "background-color:#ffffff");
+  const img = document.createElement("img");
+  img.setAttribute("id", img_url);
+  img.setAttribute("src", img_url);
+  img.setAttribute("width", "100%");
+  img.addEventListener("mousedown", () => {
+    startCount(img_url);
   });
 
-  // リアクションの書き込みのViewはいらないので削除
-  const ele = document.getElementById("console");
-  ele.parentNode.removeChild(document.getElementById("console"));
-
-  const minCellWidth = 100; //TODO: ユーザが任意に変えられるようにしようかな
-  const minCellHeight = 100;
-  const gridSize = getGridSize(window.innerWidth, window.innerHeight, minCellWidth, display_users.length);
-  const columnCount = gridSize.columnCount;
-  const rowCount = gridSize.rowCount;
-  console.log("columnCount = " + columnCount + ", rowCount = " + rowCount);
-  const cellWidth = Math.max(window.innerWidth / columnCount, minCellWidth);
-  const cellHeight = Math.max(window.innerHeight / rowCount, minCellHeight);
-
-  for (let i in display_users) {
-    const name = display_users[i];
-    let cell;
-    if (name.charAt(0) == "@") {
-      cell = createUserCell(name, cellWidth, cellHeight);
+  img.addEventListener("mouseup", () => {
+    clearInterval(mousedown_id);
+    const second = mousedown_count * 20;
+    if (second <= 20) {
+      document.getElementById("display_time").innerHTML = "20秒";
+      sendReaction(img_url, 20);
+      console.log("30sec < " + img_url);
+    } else if (second >= 600) {
+      sendReaction(img_url, 0);
+      console.log("forever < " + img_url);
     } else {
-      cell = createSensorCell(name, cellWidth, cellHeight);
+      sendReaction(img_url, second);
+      console.log(second + "sec < " + img_url);
     }
-    document.getElementById("grid_view").appendChild(cell);
-    if (cellHeight == minCellWidth) {
-      cell.style.width = Math.floor(100 / columnCount) + "%";
-      cell.style.height = minCellHeight;
-    } else if (window.innerHeight < cellHeight * rowCount) {
-      cell.style.width = Math.floor(100 / rowCount) + "%";
-      cell.style.height = Math.floor(100 / rowCount) + "%";
-    } else {
-      cell.style.width = Math.floor(100 / columnCount) + "%";
-      cell.style.height = Math.floor(100 / rowCount) + "%";
+    mousedown_count = 0;
+    document.getElementById("gauge").innerHTML = "[⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂]";
+  });
+  cell.appendChild(img);
+
+  if (append_last) {
+    document.getElementById("stamp_grid_view").appendChild(cell);
+  } else {
+    const stamp_grid_view = document.getElementById("stamp_grid_view");
+    stamp_grid_view.insertBefore(cell, stamp_grid_view.firstChild);
+  }
+};
+
+let my_images = "";
+
+// 自分で追加した画像を削除
+var removeImage = () => {
+  console.log("removeImage()");
+  const img_url = document.getElementById("image_url_text_box").value;
+  const my_images_array = Array.from(new Set(my_images.split(',')));
+  if (my_images_array.includes(img_url)) {
+    console.log("my_images_array includes " + img_url);
+    for (let i in my_images_array) {
+      console.log("my_images_array[i] = " + my_images_array[i], "img_url = " + img_url);
+      if (my_images_array[i] == img_url) {
+        console.log(img_url + " is removed!");
+        document.getElementById("stamp_grid_view").removeChild(document.getElementById(img_url + "_cell"));
+        my_images_array.splice(i, 1);
+        localStorage.images = my_images_array;
+        break;
+      }
     }
   }
+};
+
+// URLから画像を追加
+var addImage = () => {
+  const img_url = document.getElementById("image_url_text_box").value
+  appendStampCell(img_url, false);
+  if (my_images != "") {
+    my_images = my_images + ",";
+  }
+  my_images = my_images + img_url;
+  localStorage.images = my_images;
+};
+
+console.log(display_users);
+// 表示する人/物/現象のViewを動的に生成する
+const createUserCell = (from, cellWidth, cellHeight) => {
+  const cell = document.createElement("div");
+  cell.setAttribute("class", "cell");
+
+  const user_icon_layer = document.createElement("img");
+  user_icon_layer.setAttribute("class", "user_image");
+  user_icon_layer.setAttribute("id", from + "_image");
+  user_icon_layer.setAttribute("src", "http://www.paper-glasses.com/api/twipi/" + from.substring(1) + "/original");
+
+  const reaction_img_layer = document.createElement("img");
+  reaction_img_layer.setAttribute("class", "reaction_image");
+  reaction_img_layer.setAttribute("id", from + "_reaction");
+  reaction_img_layer.setAttribute("src", "https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png");
+
+  if (cellWidth >= cellHeight) {
+    user_icon_layer.setAttribute("height", "100%");
+    reaction_img_layer.setAttribute("height", "100%");
+  } else {
+    user_icon_layer.setAttribute("width", "100%");
+    reaction_img_layer.setAttribute("width", "100%");
+  }
+
+  cell.appendChild(user_icon_layer);
+  cell.appendChild(reaction_img_layer);
+  return cell;
+};
+
+const createSensorCell = (from, cellWidth, cellHeight) => {
+  const cell = document.createElement("div");
+  cell.setAttribute("class", "cell");
+
+  const sensor_img_layer = document.createElement("img");
+  sensor_img_layer.setAttribute("class", "sensor_image");
+  sensor_img_layer.setAttribute("id", from + "_image");
+  sensor_img_layer.setAttribute("src", sensor_images[from]);
+
+  const sensor_value_text_layer = document.createElement("figcaption");
+  sensor_value_text_layer.setAttribute("class", "caption");
+
+  const sensor_value_text = document.createElement("p");
+  sensor_value_text.setAttribute("id", from + "_value_text");
+
+  if (cellWidth >= cellHeight) {
+    sensor_img_layer.setAttribute("height", "100%");
+  } else {
+    sensor_img_layer.setAttribute("width", "100%");
+  }
+
+  sensor_value_text_layer.appendChild(sensor_value_text);
+  cell.appendChild(sensor_img_layer);
+  cell.appendChild(sensor_value_text_layer);
+  return cell;
+};
+
+// ウィンドウサイズと表示数からグリッドの列数と行数を算出する
+const getGridSize = (windowWidth, windowHeight, minCellWidth, itemCount) => {
+  if (itemCount <= 1) {
+    return { "columnCount": 1, "rowCount": 1 };
+  }
+
+  if (windowWidth >= windowHeight) {
+    if ((windowWidth / windowHeight) * 2 > itemCount) {
+      return { "columnCount": itemCount, "rowCount": 1 }
+    }
+  } else {
+    if ((windowHeight / windowWidth) * 2 > itemCount) {
+      return { "columnCount": 1, "rowCount": itemCount }
+    }
+  }
+
+  const cellAspectRatio = 1.0;
+  const minCellHeight = minCellWidth / cellAspectRatio;
+  const maxColumnCount = Math.min(Math.floor(windowWidth / minCellWidth), itemCount);
+  const minRowCount = Math.ceil(itemCount / maxColumnCount);
+  if (windowHeight < minRowCount * minCellHeight) {
+    return { "columnCount": maxColumnCount, "rowCount": minRowCount };
+  }
+
+  let columnCount = maxColumnCount - 1;
+  let rowCount = Math.ceil(itemCount / columnCount);
+  while (columnCount > 1) {
+    const prevColumnCount = columnCount + 1;
+    const prevRowCount = Math.ceil(itemCount / prevColumnCount);
+    if (Math.min(windowWidth / columnCount, windowHeight / rowCount)
+        < Math.min(windowWidth / prevColumnCount, windowHeight / prevRowCount)) {
+      return { "columnCount": prevColumnCount, "rowCount": prevRowCount }
+    } else {
+      columnCount -= 1;
+      rowCount = Math.ceil(itemCount / columnCount);
+    }
+  }
+  if (windowWidth >= windowHeight) return { "columnCount": Math.ceil(itemCount / 2), "rowCount": 2 };
+  else return { "columnCount": 2, "rowCount": Math.ceil(itemCount / 2) };
+};
+
+// 指定時間後に発言を非表示にする
+let timer_ids = {};
+const withdrawReaction = (reactor, time) => {
+  if (time == 0 && reactor in timer_ids) {
+    window.clearTimeout(timer_ids[reactor]);
+  } else {
+    if (reactor in timer_ids) {
+      window.clearTimeout(timer_ids[reactor]);
+    }
+    console.log("time = " + time + "msec");
+    timer_ids[reactor] = window.setTimeout(() => {
+      console.log("withdraw -> " + reactor);
+      if (sensors.includes(reactor)) {
+        document.getElementById(reactor + "_image").src = sensor_images[reactor];
+      } else {
+        document.getElementById(reactor + "_reaction").src = "https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png";
+        document.getElementById(reactor + "_image").style.opacity = 1.0;
+      }
+    }, time);
+  }
+};
+
+// Grid表示/非表示
+const switch_grid = () => {
+  const grid_style = document.getElementById("grid").style;
+  const console_button = document.getElementById("console_switch_button");
+  const grid_button = document.getElementById("grid_switch_button");
+  if (grid_style.display == "block") {
+    grid_style.display = "none";
+    grid_button.innerHTML = " 一覧表示 "
+  } else {
+    grid_style.display = "block";
+    console_button.innerHTML = " 投稿非表示 ";
+    grid_button.innerHTML = " 一覧非表示 ";
+  }
+};
+
+// Console表示/非表示
+const switch_console = () => {
+  const console_style = document.getElementById("console").style;
+  const console_button = document.getElementById("console_switch_button");
+  const grid_button = document.getElementById("grid_switch_button");
+  if (console_style.display == "block") {
+    console_style.display = "none";
+    console_button.innerHTML = " 投稿表示 "
+  } else {
+    console_style.display = "block";
+    console_button.innerHTML = " 投稿非表示 ";
+    grid_button.innerHTML = " 一覧非表示 ";
+  }
+};
+
+// consoleの生成
+// デフォルトで用意してある画像を表示
+for (let i in default_icons) {
+  appendStampCell(default_icons[i], true);
 }
+
+// localStorageから自分で追加した画像を表示
+my_images = localStorage.images || my_images;
+if (my_images.length != "") {
+  const my_images_array = Array.from(new Set(my_images.split(',')));
+  for (let i in my_images_array) {
+    console.log(my_images_array[i]);
+    appendStampCell(my_images_array[i], false);
+  }
+}
+
+// Gridの生成
+let minCellWidth = 100;
+let minCellHeight = 100;
+const grid_width = window.innerWidth - CONSOLE_WIDTH;
+const grid_height = window.innerHeight - GRID_USER_INPUT_HEIGHT;
+console.log("grid_width =" + grid_width + ", grid_height = " + grid_height);
+const gridSize = getGridSize(grid_width, grid_height, minCellWidth, display_users.length);
+const columnCount = gridSize.columnCount;
+const rowCount = gridSize.rowCount;
+console.log("columnCount = " + columnCount + ", rowCount = " + rowCount);
+const cellWidth = Math.max(grid_width / columnCount, minCellWidth);
+const cellHeight = Math.max(grid_height / rowCount, minCellHeight);
+console.log("cellWidth = " + cellWidth + ", cellHeight = " + cellHeight);
+
+for (let i in display_users) {
+  const name = display_users[i];
+  let cell;
+  if (name.charAt(0) == "@") {
+    cell = createUserCell(name, cellWidth, cellHeight);
+  } else {
+    cell = createSensorCell(name, cellWidth, cellHeight);
+  }
+  document.getElementById("grid_view").appendChild(cell);
+  if (cellHeight == minCellWidth) {
+    cell.style.width = Math.floor(100 / columnCount) + "%";
+    cell.style.height = minCellHeight;
+  } else if (grid_height < cellHeight * rowCount) {
+    cell.style.width = Math.floor(100 / rowCount) + "%";
+    cell.style.height = Math.floor(100 / rowCount) + "%";
+  } else {
+    cell.style.width = Math.floor(100 / columnCount) + "%";
+    cell.style.height = Math.floor(100 / rowCount) + "%";
+  }
+}
+
+document.getElementById("console").style.display = "block";
+document.getElementById("grid").style.display = "block";

--- a/src/index.js
+++ b/src/index.js
@@ -260,7 +260,7 @@ console.log(display_users);
 const createUserCell = (from, cellWidth, cellHeight) => {
   const cell = document.createElement("div");
   cell.setAttribute("class", "cell");
-  cell.setAttribute("div", from);
+  cell.setAttribute("id", from);
 
   const user_icon_layer = document.createElement("img");
   user_icon_layer.setAttribute("class", "user_image");
@@ -398,6 +398,7 @@ const switch_grid = () => {
       stamp_grid.style.width = "100%";
     }
   }
+  relayout_grid();
 };
 
 // Console表示/非表示
@@ -420,6 +421,7 @@ const switch_console = () => {
     grid.style.marginLeft = -410;
     grid.style.paddingLeft = 410;
   }
+  relayout_grid();
 };
 
 // consoleの生成
@@ -439,8 +441,8 @@ if (my_images.length != "") {
 }
 
 // Gridの生成
-let minCellWidth = 100;
-let minCellHeight = 100;
+let minCellWidth = 1;
+let minCellHeight = 1;
 const grid_width = window.innerWidth - CONSOLE_WIDTH;
 const grid_height = window.innerHeight - GRID_USER_INPUT_HEIGHT;
 console.log("grid_width =" + grid_width + ", grid_height = " + grid_height);
@@ -461,10 +463,7 @@ for (let i in display_users) {
     cell = createSensorCell(name, cellWidth, cellHeight);
   }
   document.getElementById("grid_view").appendChild(cell);
-  if (cellHeight == minCellWidth) {
-    cell.style.width = Math.floor(100 / columnCount) + "%";
-    cell.style.height = minCellHeight;
-  } else if (grid_height < cellHeight * rowCount) {
+  if (grid_height < cellHeight * rowCount) {
     cell.style.width = Math.floor(100 / rowCount) + "%";
     cell.style.height = Math.floor(100 / rowCount) + "%";
   } else {
@@ -475,3 +474,52 @@ for (let i in display_users) {
 
 document.getElementById("console").style.display = "block";
 document.getElementById("grid").style.display = "block";
+
+const relayout_grid = () => {
+  let minCellWidth = 1;
+  let minCellHeight = 1;
+  let grid_width;
+  let grid_height;
+  const console_style = document.getElementById("console").style;
+  if (console_style.display == "block") {
+    grid_width = window.innerWidth - CONSOLE_WIDTH;
+    grid_height = window.innerHeight - GRID_USER_INPUT_HEIGHT;
+  } else {
+    grid_width = window.innerWidth;
+    grid_height = window.innerHeight;
+  }
+  const gridSize = getGridSize(grid_width, grid_height, minCellWidth, display_users.length);
+  const columnCount = gridSize.columnCount;
+  const rowCount = gridSize.rowCount;
+  const cellWidth = Math.max(grid_width / columnCount, minCellWidth);
+  const cellHeight = Math.max(grid_height / rowCount, minCellHeight);
+
+  for (let i in display_users) {
+    let cell = document.getElementById(display_users[i]);
+    if (grid_height < cellHeight * rowCount) {
+      cell.style.width = Math.floor(100 / rowCount) + "%";
+      cell.style.height = Math.floor(100 / rowCount) + "%";
+    } else {
+      cell.style.width = Math.floor(100 / columnCount) + "%";
+      cell.style.height = Math.floor(100 / rowCount) + "%";
+    }
+
+    const user_icon_layer = cell.children[0];
+    const reaction_img_layer = cell.children[1];
+    if (cellWidth >= cellHeight) {
+      user_icon_layer.setAttribute("height", "100%");
+      user_icon_layer.removeAttribute("width");
+      reaction_img_layer.setAttribute("height", "100%");
+      reaction_img_layer.removeAttribute("width");
+    } else {
+      user_icon_layer.setAttribute("width", "100%");
+      user_icon_layer.removeAttribute("height");
+      reaction_img_layer.setAttribute("width", "100%");
+      reaction_img_layer.removeAttribute("height");
+    }
+  }
+};
+
+$(window).resize(() => {
+  relayout_grid();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -364,20 +364,14 @@ const switch_grid = () => {
   const stamp_grid = document.getElementById("stamp_grid_view");
   const console = document.getElementById("console");
   if (grid_style.display == "block") {
+    console.style.width = "100%";
     grid_style.display = "none";
     grid_button.innerHTML = " 一覧表示 ";
-    console.style.width = "100%";
-    stamp_grid.style.width = "100%";
   } else {
-    console.style.width = 400;
+    console.style.width = 410;
     grid_style.display = "block";
     console_button.innerHTML = " 投稿非表示 ";
     grid_button.innerHTML = " 一覧非表示 ";
-    if (window.innerWidth > 400) {
-      stamp_grid.style.width = 400;
-    } else {
-      stamp_grid.style.width = "100%";
-    }
   }
   relayout_grid();
 };
@@ -391,14 +385,10 @@ const switch_console = () => {
   if (console_style.display == "block") {
     console_style.display = "none";
     console_button.innerHTML = " 投稿表示 ";
-    grid.style.width = "100%";
-    grid.style.marginLeft = "0";
   } else {
     console_style.display = "block";
     console_button.innerHTML = " 投稿非表示 ";
     grid_button.innerHTML = " 一覧非表示 ";
-    grid.style.width = "";
-    grid.style.marginLeft = "410";
   }
   relayout_grid();
 };
@@ -446,6 +436,9 @@ const relayout_grid = () => {
       reaction_img_layer.removeAttribute("height");
     }
   }
+};
+
+const indexOfChild = () => {
 };
 
 var append_user = (from) => {


### PR DESCRIPTION
いらないかもしれない機能も含んでいますが、一旦masterにmergeします。
以下の実装です。
- ウィンドウサイズ変更時に一覧画面のレイアウトを再計算するようにしました
  - 常にユーザ画像が最大になるようなアルゴリズムになってます
- 投稿画面と一覧画面の行き来が簡単になりました
  - #55 でまた変更しますが
- 一覧画面で表示するユーザの追加/削除が出来るようになりました
  - ちなみに追加/削除するとURLも書き換わります
- 投稿時のゲージがかっこよくなりました
  - `npm install` のゲージを参考にしました
