### PR TITLE
アクセスした時に現在表示されているリアクションを表示するのを実装

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,14 +83,12 @@ linda.io.on("connect", () => {
       const reaction_unix_time = Math.floor(new Date(tuple.data.time).getTime() / 1000);
       const now_unix_time = Math.floor(new Date().getTime() / 1000);
       const display_time = (reaction_unix_time + tuple.data.display) - now_unix_time;
-      if (img_url != "https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png") {
-        if (display_time > 1) {
-          const reaction_style = "background:url('" + img_url + "') center center no-repeat; background-size:contain";
-          document.getElementById("console_reaction_img").setAttribute("style", reaction_style);
-          document.getElementById("image_url_text_box").value = img_url;
-          if (tuple.data.display != 0) {
-            withdrawReaction(my_name, display_time);
-          }
+      if (img_url != "https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png" && display_time > 1) {
+        const reaction_style = "background:url('" + img_url + "') center center no-repeat; background-size:contain";
+        document.getElementById("console_reaction_img").setAttribute("style", reaction_style);
+        document.getElementById("image_url_text_box").value = img_url;
+        if (tuple.data.display != 0) {
+          withdrawReaction(my_name, display_time);
         }
       }
     });
@@ -100,23 +98,12 @@ linda.io.on("connect", () => {
 
     // Watch
     ts.watch({from: my_name}, (err, tuple) => {
-      const reactor = tuple.data.from;
-      if (display_users.includes(reactor)) {
-        const img_url = tuple.data.value;
-        const time = tuple.data.time;
-        const ip_address = tuple.from;
-        console.log(reactor + " < " + img_url + " " + time + "sec (from " + ip_address + ")");
-        const style = "background:url('" + img_url + "') center center no-repeat; background-size:contain";
-        document.getElementById(reactor + "_reaction").setAttribute("style", style);
-        // 真っ白画像をリアクションした時
-        if (img_url == "https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png") {
-          document.getElementById(reactor + "_image").style.opacity = 1.0;
-        } else {
-          document.getElementById(reactor + "_image").style.opacity = 0.25;
-          if (tuple.data.display != 0) {
-            withdrawReaction(reactor, tuple.data.display);
-          }
-        }
+      const img_url = tuple.data.value;
+      const reaction_unix_time = Math.floor(new Date(tuple.data.time).getTime() / 1000);
+      const now_unix_time = Math.floor(new Date().getTime() / 1000);
+      const display_time = (reaction_unix_time + tuple.data.display) - now_unix_time;
+      if (img_url != "https://i.gyazo.com/f1b6ad7000e92d7c214d49ac3beb33be.png" && display_time > 1 && tuple.data.display != 0) {
+        withdrawReaction(my_name, display_time);
       }
     });
 
@@ -233,12 +220,10 @@ var sendReaction = (img_url, display_time) => {
   const reaction_style = "background:url('" + img_url +"') center center no-repeat; background-size:contain";
   document.getElementById("console_reaction_img").setAttribute("style", reaction_style);
   const date = new Date();
-  console.log(date);
 
   //自分の最新の発言を削除してからwriteする
   const cid = ts.take({from: my_name, type: "wakari"});
   setTimeout( () => {
-    console.log("take cancel!");
     ts.cancel(cid);
   }, 3000);
   if (display_time == 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -217,8 +217,6 @@ const display_users = Array.from(new Set(location.search.substring(1).split(',')
 var sendReaction = (img_url, display_time) => {
   my_name = "@" + document.getElementById("name_text_box").value;
   if (window.localStorage) localStorage.name = my_name;
-  const reaction_style = "background:url('" + img_url +"') center center no-repeat; background-size:contain";
-  document.getElementById("console_reaction_img").setAttribute("style", reaction_style);
   const date = new Date();
 
   //自分の最新の発言を削除してからwriteする
@@ -226,23 +224,13 @@ var sendReaction = (img_url, display_time) => {
   setTimeout( () => {
     ts.cancel(cid);
   }, 3000);
-  if (display_time == 0) {
-    ts.write({
-      from: my_name,
-      display: display_time,
-      time: date,
-      value: img_url,
-      type: "wakari"
-    }, {expire: display_time});
-  } else {
-    ts.write({
-      from: my_name,
-      display: display_time,
-      time: date,
-      value: img_url,
-      type: "wakari"
-    }, {expire: 86400});
-  }
+  ts.write({
+    from: my_name,
+    display: display_time,
+    time: date,
+    value: img_url,
+    type: "wakari"
+  }, {expire: display_time});
 
   document.getElementById("image_url_text_box").value = img_url;
   // クリックしたスタンプ画像を先頭に移動
@@ -274,14 +262,14 @@ const startCount = () => {
       }
       if (mousedown_count <= 5) {
         progress_bar.innerHTML = "20秒";
-      } else if (mousedown_count <= 15) {
+      } else if (mousedown_count <= 14) {
         progress_bar.innerHTML = "1分";
-      } else if (mousedown_count <= 25) {
+      } else if (mousedown_count <= 23) {
         progress_bar.innerHTML = "10分";
       } else if (mousedown_count < 30) {
         progress_bar.innerHTML = "1時間";
       } else {
-        progress_bar.innerHTML = "forever";
+        progress_bar.innerHTML = "1日";
       }
     }
   }, 100);
@@ -303,17 +291,19 @@ const appendStampCell = (img_url, append_last) => {
 
   cell.addEventListener("mouseup", () => {
     clearInterval(mousedown_id);
+    let display_time;
     if (mousedown_count <= 5) {
-      sendReaction(img_url, 20);
-    } else if (mousedown_count <= 15) {
-      sendReaction(img_url, 60);
-    } else if (mousedown_count <= 25) {
-      sendReaction(img_url, 600);
+      display_time = 20;
+    } else if (mousedown_count <= 14) {
+      display_time = 60;
+    } else if (mousedown_count <= 23) {
+      display_time = 600;
     } else if (mousedown_count < 30) {
-      sendReaction(img_url, 3600);
+      display_time = 3600;
     } else {
-      sendReaction(img_url, 0);
+      display_time = 86400;
     }
+    sendReaction(img_url, display_time);
     mousedown_count = 0;
     const progress = document.getElementById("console_reaction_progress");
     const progress_bar = document.getElementById("console_reaction_progress_bar");


### PR DESCRIPTION
しました。

書き込むタプルが変わりました。

```
{
  "from":"@napo0703",
  "display":20,
  "time":"2016-07-18T16:49:59.161Z",
  "value":"https://example.com/wakaru.png",
  "type":"wakari"  //なくてもいいけどデバッグ時に楽なので
}
```

1日とか長い時間表示されるものがオンメモリに残ってるとアクセス時に表示されてしまうので、writeする前に自分のタプルがあったらtakeして、常にオンメモリにある自分のリアクションが1つ以下になるようにした。
